### PR TITLE
Feature/support labels

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Piszmog/cfservices"
-	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/Piszmog/cfservices"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 const (

--- a/client.go
+++ b/client.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Piszmog/cfservices"
+	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
 	"os"
 	"strings"
 
-	"github.com/Piszmog/cfservices"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 const (

--- a/client_test.go
+++ b/client_test.go
@@ -3,12 +3,13 @@ package cloudconfigclient_test
 import (
 	"context"
 	"errors"
-	"github.com/Piszmog/cloudconfigclient/v2"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/Piszmog/cloudconfigclient/v2"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 func TestNew(t *testing.T) {

--- a/configuration.go
+++ b/configuration.go
@@ -56,11 +56,12 @@ func (s *Source) HandlePropertySources(handler PropertySourceHandler) {
 	}
 }
 
+// Get retrieve a property from the Source. It loops through all PropertySource and return the first key value.
+// If none is found, it return defaultValue.
 func (s *Source) Get(key string, defaultValue string) interface{} {
 	for _, propertySource := range s.PropertySources {
-		for _key, value := range propertySource.Source {
-			fmt.Printf("key=%s, value=%v\n", _key, value)
-			if key == _key {
+		for sourceKey, value := range propertySource.Source {
+			if key == sourceKey {
 				return value
 			}
 		}
@@ -113,13 +114,13 @@ func (s *Source) toMap() {
 	for _, propertySource := range s.PropertySources {
 		for key, value := range propertySource.Source {
 			entries := strings.Split(key, ".")
-			result = insertInMapRecursion(entries, value, result)
+			result = InsertInMapRecursion(entries, value, result)
 		}
 	}
 	s.Data = result
 }
 
-func insertInMap(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
+func InsertInMap(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
 	keys := s[:len(s)-1]
 	last := s[len(s)-1]
 
@@ -139,14 +140,14 @@ func insertInMap(s []string, value interface{}, dest map[string]interface{}) map
 	return dest
 }
 
-func insertInMapRecursion(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
+func InsertInMapRecursion(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
 	key := s[0]
 	if len(s) > 1 {
 		switch dest[key].(type) {
 		case nil:
-			dest[key] = insertInMap(s[1:], value, map[string]interface{}{})
+			dest[key] = InsertInMapRecursion(s[1:], value, map[string]interface{}{})
 		case map[string]interface{}:
-			dest[key] = insertInMap(s[1:], value, dest[key].(map[string]interface{}))
+			dest[key] = InsertInMapRecursion(s[1:], value, dest[key].(map[string]interface{}))
 		}
 	} else if len(s) == 1 {
 		if dest[key] == nil {

--- a/configuration.go
+++ b/configuration.go
@@ -1,8 +1,11 @@
 package cloudconfigclient
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -15,6 +18,7 @@ type Source struct {
 	Version         string           `json:"version"`
 	State           string           `json:"state"`
 	PropertySources []PropertySource `json:"propertySources"`
+	Data            map[string]interface{}
 }
 
 // GetPropertySource retrieves the PropertySource that has the specifies fileName. The fileName is the name of the file
@@ -52,6 +56,18 @@ func (s *Source) HandlePropertySources(handler PropertySourceHandler) {
 	}
 }
 
+func (s *Source) Get(key string, defaultValue string) interface{} {
+	for _, propertySource := range s.PropertySources {
+		for _key, value := range propertySource.Source {
+			fmt.Printf("key=%s, value=%v\n", _key, value)
+			if key == _key {
+				return value
+			}
+		}
+	}
+	return defaultValue
+}
+
 // PropertySource is the property source for the application.
 //
 // A property source is either a YAML or a PROPERTIES file located in the repository that a Config Server is pointed at.
@@ -82,6 +98,7 @@ func (c *Client) GetConfiguration(applicationName string, profiles []string, lab
 			}
 			return Source{}, err
 		}
+		source.toMap()
 		return source, nil
 	}
 	return Source{}, fmt.Errorf("failed to find configuration for application %s with profiles %s", applicationName, profiles)
@@ -89,4 +106,107 @@ func (c *Client) GetConfiguration(applicationName string, profiles []string, lab
 
 func joinProfiles(profiles []string) string {
 	return strings.Join(profiles, ",")
+}
+
+func (s *Source) toMap() {
+	result := map[string]interface{}{}
+	for _, propertySource := range s.PropertySources {
+		for key, value := range propertySource.Source {
+			entries := strings.Split(key, ".")
+			result = insertInMapRecursion(entries, value, result)
+		}
+	}
+	s.Data = result
+}
+
+func insertInMap(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
+	keys := s[:len(s)-1]
+	last := s[len(s)-1]
+
+	curr := dest
+	for _, key := range keys {
+		switch curr[key].(type) {
+		case nil:
+			curr[key] = map[string]interface{}{}
+			curr = curr[key].(map[string]interface{})
+		case map[string]interface{}:
+			curr = curr[key].(map[string]interface{})
+		}
+	}
+	if curr[last] == nil {
+		curr[last] = value
+	}
+	return dest
+}
+
+func insertInMapRecursion(s []string, value interface{}, dest map[string]interface{}) map[string]interface{} {
+	key := s[0]
+	if len(s) > 1 {
+		switch dest[key].(type) {
+		case nil:
+			dest[key] = insertInMap(s[1:], value, map[string]interface{}{})
+		case map[string]interface{}:
+			dest[key] = insertInMap(s[1:], value, dest[key].(map[string]interface{}))
+		}
+	} else if len(s) == 1 {
+		if dest[key] == nil {
+			dest[key] = value
+		}
+	}
+	return dest
+}
+
+type BasicAuthTransport struct {
+	Username string
+	Password string
+}
+
+func (bat BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
+		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s",
+			bat.Username, bat.Password)))))
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func (bat *BasicAuthTransport) client() *http.Client {
+	return &http.Client{Transport: bat}
+}
+
+type ConfigsEnv struct {
+	username string
+	password string
+	url      string
+	name     string
+	profiles string
+	label    string
+}
+
+func (c *ConfigsEnv) ReadFromEnv() *ConfigsEnv {
+	c.url = os.Getenv("CONFIG_URL")
+	c.username = os.Getenv("CONFIG_USERNAME")
+	c.password = os.Getenv("CONFIG_PASSWORD")
+	c.name = os.Getenv("APPLICATION_NAME")
+	c.profiles = os.Getenv("APPLICATION_PROFILES")
+	c.label = os.Getenv("CONFIG_LABEL")
+	return c
+}
+func (configsEnv ConfigsEnv) Load() (Source, error) {
+	transport := BasicAuthTransport{Username: configsEnv.username, Password: configsEnv.password}
+	client := transport.client()
+	configConf := Local(client, configsEnv.url)
+	configClient, err := New(configConf)
+
+	if err != nil {
+		fmt.Println(err)
+		return Source{}, err
+	}
+
+	// Retrieves the configurations from the Config Server based on the application name, active profiles and label
+	source, err := configClient.GetConfiguration(configsEnv.name, strings.Split(configsEnv.profiles, ","), configsEnv.label)
+	if err != nil {
+		fmt.Println(err)
+		return Source{}, err
+	}
+
+	return source, nil
 }

--- a/configuration.go
+++ b/configuration.go
@@ -69,9 +69,12 @@ type Configuration interface {
 
 // GetConfiguration retrieves the configurations/property sources of an application based on the name of the application
 // and the profiles of the application.
-func (c *Client) GetConfiguration(applicationName string, profiles ...string) (Source, error) {
+func (c *Client) GetConfiguration(applicationName string, profiles []string, label string) (Source, error) {
 	var source Source
 	paths := []string{applicationName, joinProfiles(profiles)}
+	if label != "" {
+		paths = append(paths, label)
+	}
 	for _, client := range c.clients {
 		if err := client.GetResource(paths, nil, &source); err != nil {
 			if errors.Is(err, ErrResourceNotFound) {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -3,12 +3,11 @@ package cloudconfigclient_test
 import (
 	"errors"
 	"net/http"
-	"reflect"
-	"testing"
-
-	"github.com/duvalhub/cloudconfigclient"
+	"github.com/cloudconfigclient/cloudconfigclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
 )
 
 const (
@@ -105,7 +104,7 @@ func TestClient_GetConfiguration(t *testing.T) {
 			})
 			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
 			require.NoError(t, err)
-			configuration, err := client.GetConfiguration(test.application, test.profiles...)
+			configuration, err := client.GetConfiguration(test.application, test.profiles, "")
 			if err != nil {
 				require.Error(t, err)
 				require.Equal(t, test.err.Error(), err.Error())
@@ -177,7 +176,6 @@ func TestSource_HandlePropertySources_NonFileExcluded(t *testing.T) {
 }
 
 func TestInsertInMap(t *testing.T) {
-
 	type args struct {
 		s     []string
 		value string
@@ -340,7 +338,7 @@ func TestInsertInMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := insertInMapRecursion(tt.args.s, tt.args.value, tt.args.dest)
+			got := cloudconfigclient.InsertInMapRecursion(tt.args.s, tt.args.value, tt.args.dest)
 			if !reflect.DeepEqual(tt.want, got) {
 				t.Errorf("insertInMap() = %v, want %v", got, tt.want)
 			}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -2,11 +2,13 @@ package cloudconfigclient_test
 
 import (
 	"errors"
-	"github.com/Piszmog/cloudconfigclient/v2"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/duvalhub/cloudconfigclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
 )
 
 const (
@@ -172,4 +174,176 @@ func TestSource_HandlePropertySources_NonFileExcluded(t *testing.T) {
 		count++
 	})
 	assert.Equal(t, 3, count)
+}
+
+func TestInsertInMap(t *testing.T) {
+
+	type args struct {
+		s     []string
+		value string
+		dest  map[string]interface{}
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "allo",
+			args: args{
+				s:     []string{"a"},
+				value: "allo",
+				dest: map[string]interface{}{
+					"a": "toto",
+				},
+			},
+			want: map[string]interface{}{
+				"a": "toto",
+			},
+		},
+		{
+			name: "allo",
+			args: args{
+				s:     []string{"a"},
+				value: "allo",
+				dest: map[string]interface{}{
+					"asd": "qwe",
+				},
+			},
+			want: map[string]interface{}{
+				"a":   "allo",
+				"asd": "qwe",
+			},
+		},
+		{
+			name: "b.a",
+			args: args{
+				s:     []string{"b", "a"},
+				value: "allo",
+				dest:  map[string]interface{}{},
+			},
+			want: map[string]interface{}{
+				"b": map[string]interface{}{
+					"a": "allo",
+				},
+			},
+		},
+		{
+			name: "b.a already set",
+			args: args{
+				s:     []string{"b", "a"},
+				value: "allo",
+				dest: map[string]interface{}{
+					"b": map[string]interface{}{
+						"a": "bye",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"b": map[string]interface{}{
+					"a": "bye",
+				},
+			},
+		},
+		{
+			name: "c.b.a",
+			args: args{
+				s:     []string{"c", "b", "a"},
+				value: "allo",
+				dest:  map[string]interface{}{},
+			},
+			want: map[string]interface{}{
+				"c": map[string]interface{}{
+					"b": map[string]interface{}{
+						"a": "allo",
+					},
+				},
+			},
+		},
+		{
+			name: "c.b.a",
+			args: args{
+				s:     []string{"a", "b", "c"},
+				value: "bye",
+				dest: map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": map[string]interface{}{
+							"d": "allo",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"d": "allo",
+						"c": "bye",
+					},
+				},
+			},
+		},
+		{
+			name: "c.b. asdasa",
+			args: args{
+				s:     []string{"files", "fileb", "size"},
+				value: "20",
+				dest: map[string]interface{}{
+					"app": map[string]interface{}{
+						"source": map[string]interface{}{
+							"git":     "github.com",
+							"version": "1.2.3",
+						},
+						"attributes": map[string]interface{}{
+							"name": "myapp",
+						},
+					},
+					"files": map[string]interface{}{
+						"filea": map[string]interface{}{
+							"name": "filea",
+							"size": "12",
+						},
+						"fileb": map[string]interface{}{
+							"name": "fileb",
+						},
+						"filec": map[string]interface{}{
+							"name": "filec",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"app": map[string]interface{}{
+					"source": map[string]interface{}{
+						"git":     "github.com",
+						"version": "1.2.3",
+					},
+					"attributes": map[string]interface{}{
+						"name": "myapp",
+					},
+				},
+				"files": map[string]interface{}{
+					"filea": map[string]interface{}{
+						"name": "filea",
+						"size": "12",
+					},
+					"fileb": map[string]interface{}{
+						"name": "fileb",
+						"size": "20",
+					},
+					"filec": map[string]interface{}{
+						"name": "filec",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := insertInMapRecursion(tt.args.s, tt.args.value, tt.args.dest)
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("insertInMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/duvalhub/cloudconfigclient
+module github.com/Piszmog/cloudconfigclient/v2
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/Piszmog/cfservices v1.4.3
+	github.com/Piszmog/cloudconfigclient/v2 v2.0.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/duvalhub/cloudconfigclient/v2
+module github.com/duvalhub/cloudconfigclient
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Piszmog/cloudconfigclient/v2
+module github.com/duvalhub/cloudconfigclient/v2
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Piszmog/cfservices v1.4.3 h1:Ep2VrJ1c04qfDGv4klfCterPFTPv+3tVLQV5fcVy8uw=
 github.com/Piszmog/cfservices v1.4.3/go.mod h1:5SDyIoLVCxgkJhmB/ZFYbZ4yu3OEU5K78HseD8uFijE=
+github.com/Piszmog/cloudconfigclient/v2 v2.0.1 h1:3tEeAOocAIj6Zs6cowkKpekkMYPIvLu8lJu8fX+kUTs=
+github.com/Piszmog/cloudconfigclient/v2 v2.0.1/go.mod h1:Ne2TIL8jsxREGjEz4oGyX2cF5z4hM9z6wIU+8oTRp3I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/http_test.go
+++ b/http_test.go
@@ -3,11 +3,12 @@ package cloudconfigclient_test
 import (
 	"bytes"
 	"errors"
-	"github.com/Piszmog/cloudconfigclient/v2"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/Piszmog/cloudconfigclient/v2"
+	"github.com/stretchr/testify/require"
 )
 
 type RoundTripFunc func(req *http.Request) *http.Response


### PR DESCRIPTION
### Changes Description
Added support for labels. A spring config server path is "app/profiles/label" . https://cloud.spring.io/spring-cloud-config/reference/html/#_locating_remote_configuration_resources

Flatting the configuration in a "map" way.

From
```
{
 "my.config1": "value",
 "my.config2": "value2"
}
```
to
```
{
 "my": {
    "config1": "value,
    "config2": "value2"
  }
}
```

### Associated Issues
I needed the labels and a get_property function to retrieve "my.config1" value for example. 

### Affected Files
See commits 

### Unit Tests Changed or Added
I've added tests for all files


Let me know if this interested you. I'll will probably add more functionality to this lib as I go along.
