### PR TITLE
Feat/added basic auth authenication

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ type Example struct {
 }
 
 func main() {
-	// To create a Client for a locally running Spring Config Server
+	// To create a Client for a locally running Spring Config Server without credentials
 	configClient, err := cloudconfigclient.New(cloudconfigclient.LocalEnv(&http.Client{}))
 	// Or
 	configClient, err = cloudconfigclient.New(cloudconfigclient.Local(&http.Client{}, "http://localhost:8888"))
+	// To create a Client for a locally running Spring Config Server with credentials
+	configClient, err := cloudconfigclient.New(cloudconfigclient.LocalEnv(&http.Client{}, &cloudconfigclient.BasicAuthCredential{Username: '', Password: ''}))
+	// Or
+	configClient, err = cloudconfigclient.New(cloudconfigclient.Local(&http.Client{}, &cloudconfigclient.BasicAuthCredential{Username: '', Password: ''}, "http://localhost:8888"))
 	// or to create a Client for a Spring Config Server in Cloud Foundry
 	configClient, err = cloudconfigclient.New(cloudconfigclient.DefaultCFService())
 	// or to create a Client for a Spring Config Server with OAuth2

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -2,11 +2,12 @@ package cloudconfigclient_test
 
 import (
 	"errors"
+	"net/http"
+	"testing"
+
 	"github.com/Piszmog/cloudconfigclient/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
 )
 
 const (
@@ -101,7 +102,7 @@ func TestClient_GetConfiguration(t *testing.T) {
 				}
 				return test.response
 			})
-			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
+			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 			require.NoError(t, err)
 			configuration, err := client.GetConfiguration(test.application, test.profiles...)
 			if err != nil {

--- a/examples/local/main.go
+++ b/examples/local/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/Piszmog/cloudconfigclient/v2"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/Piszmog/cloudconfigclient/v2"
 )
 
 func main() {
 	// ensure you have the Config Server running locally...
 
-	client, err := cloudconfigclient.New(cloudconfigclient.Local(&http.Client{}, "http://localhost:8888"))
+	client, err := cloudconfigclient.New(cloudconfigclient.Local(&http.Client{}, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/resource_test.go
+++ b/resource_test.go
@@ -2,10 +2,11 @@ package cloudconfigclient_test
 
 import (
 	"errors"
-	"github.com/Piszmog/cloudconfigclient/v2"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+
+	"github.com/Piszmog/cloudconfigclient/v2"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -59,7 +60,7 @@ func TestClient_GetFile(t *testing.T) {
 				}
 				return test.response
 			})
-			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
+			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 			require.NoError(t, err)
 
 			var actual file
@@ -110,7 +111,7 @@ func TestClient_GetFileFromBranch(t *testing.T) {
 				}
 				return test.response
 			})
-			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
+			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 			require.NoError(t, err)
 
 			var actual file
@@ -161,7 +162,7 @@ func TestClient_GetFileRaw(t *testing.T) {
 				}
 				return test.response
 			})
-			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
+			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 			require.NoError(t, err)
 
 			actual, err := client.GetFileRaw("directory", "file.txt")
@@ -211,7 +212,7 @@ func TestClient_GetFileFromBranchRaw(t *testing.T) {
 				}
 				return test.response
 			})
-			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, "http://localhost:8888"))
+			client, err := cloudconfigclient.New(cloudconfigclient.Local(httpClient, &cloudconfigclient.BasicAuthCredential{}, "http://localhost:8888"))
 			require.NoError(t, err)
 
 			actual, err := client.GetFileFromBranchRaw("branch", "directory", "file.txt")


### PR DESCRIPTION
### Changes Description
Spring boot cloud config server allow authentication, the current implementation doesn't cater for this. 
The changes enable user to pass the username and password when initialising the library.

### Associated Issues


### Affected Files
http.go
client.go
README.md
examples/local/main.go

### Unit Tests Changed or Added
client_test.go
configuration_test.go
resource_test.go